### PR TITLE
Fix data display

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -681,10 +681,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         try {
             // Now reading from local Dexie DB
-            const guides = await db.guides
-                .where('available_langs')
-                .equals(selectedLanguage)
-                .toArray();
+            // Fetch all guides; filtering is handled by the rendering logic's language fallback.
+            const guides = await db.guides.toArray();
 
             // Note: The editor-specific view of drafts is lost in this simple offline model.
             // That would be part of a more complex sync strategy in Phase 2.

--- a/js/main.js
+++ b/js/main.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
     db.version(3).stores({
         guides: 'id, slug, *available_langs', // Primary key 'id', index on 'slug' and 'available_langs'
         guide_poi: 'id, guide_id', // Primary key 'id', index on 'guide_id'
-        mutations: '++id, error_count' // Auto-incrementing PK, index on error_count for querying failed mutations
+        mutations: '++id, createdAt, error_count' // Auto-incrementing PK, index on createdAt and error_count
     });
 
     // -----------------------------------------------------------------------------

--- a/js/main.js
+++ b/js/main.js
@@ -669,6 +669,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     });
                 });
             }
+
+            guideCatalogList.appendChild(card);
         });
     }
 

--- a/js/main.js
+++ b/js/main.js
@@ -2012,6 +2012,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
             console.log(`Sync from Supabase complete. Stored ${guides.length} guides and ${pois.length} POIs locally.`);
 
+            // Refresh the guide list now that the sync is complete
+            await fetchAndDisplayGuides();
+
             // PHASE 2: Sync local mutations back to Supabase
             const localMutations = await db.mutations.orderBy('createdAt').toArray();
             if (localMutations.length > 0) {


### PR DESCRIPTION
fix: Add missing appendChild call to render guides

This commit fixes the ultimate root cause of the guides not appearing in the UI. The `renderGuideList` function would create the card element for each guide but would fail to append it to the DOM, resulting in a blank list.

This is the final of a series of fixes:
1.  A missing `appendChild` call in the rendering logic (this commit).
2.  A missing `createdAt` index in the Dexie DB schema that crashed the sync process.
3.  Overly restrictive language filtering that hid guides without a direct translation.
4.  A race condition on initial load where the UI would render before the first sync was complete.

With all four issues addressed, the application should now reliably sync and display all guides.